### PR TITLE
feat(ui): unify job description input with semantic highlighter

### DIFF
--- a/app/components/JobInputHighlighter.tsx
+++ b/app/components/JobInputHighlighter.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useMemo, useRef, useState, type MouseEvent } from "react";
+import { buildSemanticHighlightMatches, buildSemanticHighlightParts } from "@/lib/semanticHighlightMatcher";
+import type { SemanticHighlight } from "@/types/pipeline";
+
+type JobInputHighlighterProps = {
+  id: string;
+  value: string;
+  onChange: (value: string) => void;
+  highlights?: SemanticHighlight[];
+  placeholder?: string;
+};
+
+type HighlightTooltip = {
+  phrase: string;
+  reason: string;
+  sentiment: "positive" | "negative";
+  x: number;
+  y: number;
+};
+
+const MIRROR_TEXT_STYLES = {
+  fontFamily: "Arial, Helvetica, sans-serif",
+  fontSize: "0.875rem",
+  lineHeight: "1.625",
+  padding: "0.75rem",
+};
+
+export default function JobInputHighlighter({
+  id,
+  value,
+  onChange,
+  highlights = [],
+  placeholder = "Paste the full job posting here…",
+}: JobInputHighlighterProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const mirrorScrollRef = useRef<HTMLDivElement>(null);
+  const [tooltip, setTooltip] = useState<HighlightTooltip | null>(null);
+  const tooltipTargetIdRef = useRef<string | null>(null);
+
+  const matches = useMemo(
+    () => buildSemanticHighlightMatches(value, highlights),
+    [highlights, value],
+  );
+  const parts = useMemo(() => buildSemanticHighlightParts(value, matches), [matches, value]);
+  const hasHighlights = highlights.length > 0;
+
+  const syncMirrorScroll = () => {
+    const textarea = textareaRef.current;
+    const mirror = mirrorScrollRef.current;
+    if (!textarea || !mirror) {
+      return;
+    }
+    mirror.scrollTop = textarea.scrollTop;
+    mirror.scrollLeft = textarea.scrollLeft;
+  };
+
+  const handleOverlayMouseMove = (event: MouseEvent<HTMLDivElement>) => {
+    const layeredElements = document.elementsFromPoint(event.clientX, event.clientY);
+    const hoveredMatch = layeredElements.find(
+      (element): element is HTMLElement =>
+        element instanceof HTMLElement && Boolean(element.dataset.semanticReason),
+    );
+
+    if (!hoveredMatch) {
+      if (tooltip) {
+        setTooltip(null);
+      }
+      tooltipTargetIdRef.current = null;
+      return;
+    }
+
+    const targetId = hoveredMatch.dataset.semanticId ?? null;
+    if (
+      tooltipTargetIdRef.current === targetId &&
+      tooltip?.phrase === (hoveredMatch.dataset.semanticPhrase ?? "") &&
+      tooltip?.reason === (hoveredMatch.dataset.semanticReason ?? "") &&
+      tooltip?.x === event.clientX &&
+      tooltip?.y === event.clientY
+    ) {
+      return;
+    }
+
+    tooltipTargetIdRef.current = targetId;
+
+    setTooltip({
+      phrase: hoveredMatch.dataset.semanticPhrase ?? "",
+      reason: hoveredMatch.dataset.semanticReason ?? "",
+      sentiment:
+        hoveredMatch.dataset.semanticSentiment === "negative" ? "negative" : "positive",
+      x: event.clientX,
+      y: event.clientY,
+    });
+  };
+
+  return (
+    <div
+      className="space-y-2"
+      onMouseMove={handleOverlayMouseMove}
+      onMouseLeave={() => {
+        tooltipTargetIdRef.current = null;
+        setTooltip(null);
+      }}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <label htmlFor={id} className="text-sm font-medium text-slate-200">
+          Job description
+        </label>
+        {hasHighlights ? (
+          <span className="inline-flex items-center gap-1 rounded-full border border-emerald-700/80 bg-emerald-950/50 px-2 py-0.5 text-[11px] font-medium text-emerald-200">
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-300" aria-hidden />
+            Highlights Active
+          </span>
+        ) : null}
+      </div>
+      <p className="text-xs text-slate-500">
+        Edit normally. Hover highlighted phrases to inspect semantic rationale.
+      </p>
+
+      <div className="relative rounded-md border border-slate-700 bg-slate-950">
+        <div
+          ref={mirrorScrollRef}
+          aria-hidden
+          className="absolute inset-0 overflow-auto rounded-md"
+        >
+          <div style={MIRROR_TEXT_STYLES} className="min-h-[14rem] whitespace-pre-wrap break-words md:min-h-[22rem]">
+            {value.length === 0 ? (
+              <span className="text-slate-500">{placeholder}</span>
+            ) : (
+              <>
+                {parts.map((part) => {
+                  if (!part.match) {
+                    return (
+                      <span key={part.id} className="text-slate-200">
+                        {part.text}
+                      </span>
+                    );
+                  }
+                  const highlightClass =
+                    part.match.sentiment === "positive"
+                      ? "bg-emerald-700/55 text-emerald-50 ring-1 ring-emerald-500/30"
+                      : "bg-rose-800/55 text-rose-50 ring-1 ring-rose-500/35";
+                  return (
+                    <mark
+                      key={part.id}
+                      data-semantic-id={part.id}
+                      data-semantic-phrase={part.text}
+                      data-semantic-reason={part.match.reason}
+                      data-semantic-sentiment={part.match.sentiment}
+                      className={`rounded px-0.5 ${highlightClass}`}
+                    >
+                      {part.text}
+                    </mark>
+                  );
+                })}
+                {value.endsWith("\n") ? <span>{"\u00A0"}</span> : null}
+              </>
+            )}
+          </div>
+        </div>
+
+        <textarea
+          ref={textareaRef}
+          id={id}
+          value={value}
+          onChange={(event) => {
+            onChange(event.target.value);
+            requestAnimationFrame(syncMirrorScroll);
+          }}
+          onScroll={syncMirrorScroll}
+          placeholder={placeholder}
+          className="relative z-10 block min-h-[14rem] w-full resize-y overflow-auto rounded-md bg-transparent text-transparent caret-black focus:outline-none md:min-h-[22rem]"
+          style={MIRROR_TEXT_STYLES}
+        />
+      </div>
+
+      {tooltip ? (
+        <div
+          role="tooltip"
+          className="pointer-events-none fixed z-50 max-w-xs rounded-md border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-slate-100 shadow-lg shadow-slate-950/80"
+          style={{ left: tooltip.x + 12, top: tooltip.y + 12 }}
+        >
+          <p className="font-medium text-slate-200">{tooltip.phrase}</p>
+          <p
+            className={
+              tooltip.sentiment === "positive" ? "text-emerald-300" : "text-rose-300"
+            }
+          >
+            {tooltip.sentiment === "positive" ? "Positive signal" : "Negative signal"}
+          </p>
+          <p className="mt-0.5 text-slate-300">{tooltip.reason}</p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useState } from "react";
+import JobInputHighlighter from "@/app/components/JobInputHighlighter";
 import type { SemanticHighlight } from "@/types/pipeline";
 
 type UploadStatus = {
@@ -97,83 +98,6 @@ function FitGauge({ score, vetoed }: { score: number; vetoed: boolean }) {
   );
 }
 
-function JobTextWithHighlights({
-  text,
-  highlights,
-}: {
-  text: string;
-  highlights: SemanticHighlight[];
-}) {
-  if (!highlights.length) {
-    return null;
-  }
-  type Mark = { start: number; end: number; sentiment: "positive" | "negative"; reason: string };
-  const marks: Mark[] = [];
-  const lower = text.toLowerCase();
-  const sorted = [...highlights]
-    .filter((h) => h.phrase?.trim())
-    .sort((a, b) => b.phrase.trim().length - a.phrase.trim().length);
-  const used = new Array(text.length).fill(false);
-  for (const h of sorted) {
-    const p = h.phrase.trim();
-    let from = 0;
-    while (true) {
-      const idx = lower.indexOf(p.toLowerCase(), from);
-      if (idx === -1) break;
-      let overlap = false;
-      for (let i = idx; i < idx + p.length; i++) {
-        if (used[i]) {
-          overlap = true;
-          break;
-        }
-      }
-      if (!overlap) {
-        for (let i = idx; i < idx + p.length; i++) used[i] = true;
-        marks.push({
-          start: idx,
-          end: idx + p.length,
-          sentiment: h.sentiment,
-          reason: h.reason,
-        });
-      }
-      from = idx + 1;
-    }
-  }
-  marks.sort((a, b) => a.start - b.start);
-  const nodes: ReactNode[] = [];
-  let pos = 0;
-  let k = 0;
-  for (const m of marks) {
-    if (m.start < pos) continue;
-    if (m.start > pos) {
-      nodes.push(<span key={`t-${k++}`}>{text.slice(pos, m.start)}</span>);
-    }
-    const cls =
-      m.sentiment === "positive"
-        ? "bg-emerald-700/55 text-emerald-50 ring-1 ring-emerald-500/30"
-        : "bg-rose-800/55 text-rose-50 ring-1 ring-rose-500/35";
-    nodes.push(
-      <mark key={`m-${m.start}-${m.end}`} title={m.reason} className={`rounded px-0.5 ${cls}`}>
-        {text.slice(m.start, m.end)}
-      </mark>,
-    );
-    pos = m.end;
-  }
-  if (pos < text.length) {
-    nodes.push(<span key={`t-${k++}`}>{text.slice(pos)}</span>);
-  }
-
-  return (
-    <div className="space-y-1">
-      <p className="text-xs font-medium text-slate-400">Semantic highlights</p>
-      <p className="text-[11px] text-slate-500">Hover a mark for the model&apos;s rationale.</p>
-      <div className="max-h-72 overflow-auto whitespace-pre-wrap rounded-md border border-slate-700 bg-slate-950/80 p-3 text-sm leading-relaxed text-slate-200">
-        {nodes.length ? nodes : text}
-      </div>
-    </div>
-  );
-}
-
 export default function DashboardPage() {
   const [status, setStatus] = useState<UploadStatus>({ loaded: false });
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -227,7 +151,12 @@ export default function DashboardPage() {
   }, []);
 
   useEffect(() => {
-    void loadOllamaModels();
+    const timerId = window.setTimeout(() => {
+      void loadOllamaModels();
+    }, 0);
+    return () => {
+      window.clearTimeout(timerId);
+    };
   }, [loadOllamaModels]);
 
   useEffect(() => {
@@ -581,24 +510,13 @@ export default function DashboardPage() {
                 </button>
               </div>
 
-              <div>
-                <label htmlFor="job-description" className="text-sm font-medium text-slate-200">
-                  Job description
-                </label>
-                <textarea
-                  id="job-description"
-                  value={jobText}
-                  onChange={(event) => setJobText(event.target.value)}
-                  placeholder="Paste the full job posting here…"
-                  className="mt-1 min-h-[14rem] w-full rounded-md border border-slate-700 bg-slate-950 p-3 text-sm leading-relaxed md:min-h-[22rem]"
-                />
-              </div>
-              {result?.semantic_highlights?.length ? (
-                <JobTextWithHighlights
-                  text={jobText}
-                  highlights={result.semantic_highlights}
-                />
-              ) : null}
+              <JobInputHighlighter
+                id="job-description"
+                value={jobText}
+                onChange={setJobText}
+                highlights={result?.semantic_highlights ?? []}
+                placeholder="Paste the full job posting here…"
+              />
 
               <div className="flex flex-wrap items-center gap-2 border-t border-slate-800 pt-3">
                 <label htmlFor="ollama-model" className="text-sm text-slate-300">

--- a/apps/extension/src/App.tsx
+++ b/apps/extension/src/App.tsx
@@ -106,7 +106,12 @@ export function App() {
   }, []);
 
   useEffect(() => {
-    void loadOllamaModels();
+    const timerId = window.setTimeout(() => {
+      void loadOllamaModels();
+    }, 0);
+    return () => {
+      window.clearTimeout(timerId);
+    };
   }, [loadOllamaModels]);
 
   useEffect(() => {

--- a/lib/semanticHighlightMatcher.ts
+++ b/lib/semanticHighlightMatcher.ts
@@ -1,0 +1,114 @@
+import type { SemanticHighlight } from "@/types/pipeline";
+
+export type SemanticHighlightMatch = {
+  id: string;
+  start: number;
+  end: number;
+  sentiment: "positive" | "negative";
+  reason: string;
+};
+
+export type SemanticHighlightPart = {
+  id: string;
+  text: string;
+  match: SemanticHighlightMatch | null;
+};
+
+export function buildSemanticHighlightMatches(
+  text: string,
+  highlights: SemanticHighlight[],
+): SemanticHighlightMatch[] {
+  if (!text || highlights.length === 0) {
+    return [];
+  }
+
+  const matches: Omit<SemanticHighlightMatch, "id">[] = [];
+  const lowerText = text.toLowerCase();
+  const used = new Array(text.length).fill(false);
+  const sortedHighlights = [...highlights]
+    .filter((highlight) => highlight.phrase?.trim())
+    .sort((a, b) => b.phrase.trim().length - a.phrase.trim().length);
+
+  for (const highlight of sortedHighlights) {
+    const phrase = highlight.phrase.trim();
+    const normalizedPhrase = phrase.toLowerCase();
+    let from = 0;
+
+    while (true) {
+      const index = lowerText.indexOf(normalizedPhrase, from);
+      if (index === -1) {
+        break;
+      }
+
+      let overlaps = false;
+      for (let cursor = index; cursor < index + phrase.length; cursor += 1) {
+        if (used[cursor]) {
+          overlaps = true;
+          break;
+        }
+      }
+
+      if (!overlaps) {
+        for (let cursor = index; cursor < index + phrase.length; cursor += 1) {
+          used[cursor] = true;
+        }
+        matches.push({
+          start: index,
+          end: index + phrase.length,
+          sentiment: highlight.sentiment,
+          reason: highlight.reason,
+        });
+      }
+
+      from = index + 1;
+    }
+  }
+
+  matches.sort((a, b) => a.start - b.start);
+  return matches.map((match, index) => ({ ...match, id: `semantic-match-${index}-${match.start}` }));
+}
+
+export function buildSemanticHighlightParts(
+  text: string,
+  matches: SemanticHighlightMatch[],
+): SemanticHighlightPart[] {
+  if (!text) {
+    return [];
+  }
+
+  const parts: SemanticHighlightPart[] = [];
+  let cursor = 0;
+  let plainIndex = 0;
+
+  for (const match of matches) {
+    if (match.start < cursor) {
+      continue;
+    }
+
+    if (match.start > cursor) {
+      parts.push({
+        id: `plain-${plainIndex}`,
+        text: text.slice(cursor, match.start),
+        match: null,
+      });
+      plainIndex += 1;
+    }
+
+    parts.push({
+      id: match.id,
+      text: text.slice(match.start, match.end),
+      match,
+    });
+    cursor = match.end;
+  }
+
+  if (cursor < text.length) {
+    parts.push({
+      id: `plain-${plainIndex}`,
+      text: text.slice(cursor),
+      match: null,
+    });
+  }
+
+  return parts;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eliza",
-  "version": "0.2.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eliza",
-      "version": "0.2.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "autoprefixer": "^10.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eliza",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "private": true,
   "description": "AI-powered career co-pilot for local job-fit analysis with Ollama, Next.js, and TypeScript",
   "author": "NyiroM (https://github.com/NyiroM)",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace the dashboard's separate semantic-highlights panel with a single `JobInputHighlighter` field that combines editing and highlighting
- implement a mirror-overlay input: transparent foreground textarea + synchronized background mirror with semantic `<mark>` spans
- preserve rationale hover behavior by resolving underlying highlighted elements with `document.elementsFromPoint(...)` and rendering a lightweight tooltip
- add a `Highlights Active` indicator when analysis results include semantic highlights
- extract highlight phrase-to-text matching into `lib/semanticHighlightMatcher.ts` to keep UI logic clean
- bump root package version to `0.4.1`
- keep extension UI stable and lint-clean by aligning initial model loading with the updated React hook lint rule

## Verification
- `npm run lint` (root) ✅ passes with pre-existing warnings only (unused vars in unrelated files)
- `npm run build` (root) ✅
- `npm run lint` (apps/extension) ✅ (tool prints a known Next pages-directory notice, no lint errors)
- `npm run build` (apps/extension) ✅
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-116fe0c3-86b6-47ed-bcaf-5a87296a38ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-116fe0c3-86b6-47ed-bcaf-5a87296a38ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

